### PR TITLE
Make structs derive more traits

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 /// Rows of the image. Call `Img.rows()` to create it.
 ///
 /// Each element is a slice `width` pixels wide. Ignores padding, if there's any.
+#[derive(Debug)]
 pub struct RowsIter<'a, T: 'a> {
     pub(crate) width: usize,
     pub(crate) inner: slice::Chunks<'a, T>,
@@ -44,6 +45,7 @@ impl<'a, T> ExactSizeIterator for RowsIter<'a, T> {}
 /// Rows of the image. Call `Img.rows_mut()` to create it.
 ///
 /// Each element is a slice `width` pixels wide. Ignores padding, if there's any.
+#[derive(Debug)]
 pub struct RowsIterMut<'a, T: 'a> {
     pub(crate) width: usize,
     pub(crate) inner: slice::ChunksMut<'a, T>,
@@ -84,6 +86,7 @@ impl<'a, T> ExactSizeIterator for RowsIterMut<'a, T> {}
 /// Iterates over pixels in the (sub)image. Call `Img.pixels()` to create it.
 ///
 /// Ignores padding, if there's any.
+#[derive(Debug)]
 pub struct PixelsIter<'a, T: Copy + 'a> {
     current: *const T,
     current_line_end: *const T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub trait ImgExtMut<Pixel> {
 /// Basic struct used for both owned (alias `ImgVec`) and borrowed (alias `ImgRef`) image fragments.
 ///
 /// Note: the fields are `pub` only because of borrow checker limitations. Please consider them as read-only.
-#[derive(Clone)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Img<Container> {
     /// Storage for the pixels. Usually `Vec<Pixel>` or `&[Pixel]`. See `ImgVec` and `ImgRef`.
     ///
@@ -172,9 +172,6 @@ impl<Pixel,Container> ImgExtMut<Pixel> for Img<Container> where Container: AsMut
         self.buf.as_mut().chunks_mut(stride)
     }
 }
-
-/// References (`ImgRef`) should be passed "by value" to avoid a double indirection of `&Img<&[]>`.
-impl<'a, T> Copy for ImgRef<'a, T> {}
 
 impl<'a, T> ImgRef<'a, T> {
     /// Make a reference for a part of the image, without copying any pixels.
@@ -375,6 +372,18 @@ impl<OldContainer> Img<OldContainer> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    mod with_opinionated_container {
+        use super::*;
+
+        struct IDontDeriveAnything;
+
+        #[test]
+        fn compiles() {
+            let _ = Img::new(IDontDeriveAnything, 1, 1);
+        }
+    }
+
     #[test]
     fn with_vec() {
         let bytes = vec![0u8;20];


### PR DESCRIPTION
Self-explanatory; I suspect there was a reason for not deriving that many traits in the first place, but it's way more convenient from my point of view as an API writer that use imgref.

Deriving Debug for Img might not be such a good idea though; Wouldn't it flood the screen ? x) Either way, thanks in advance for considering this PR.