### PR TITLE
Add buf(), buf_mut() and into_buf()

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -100,10 +100,10 @@ impl<'a, T: Copy + 'a> PixelsIter<'a, T> {
     pub(crate) fn new(img: super::ImgRef<'a, T>) -> Self {
         let width = img.width();
         let stride = img.stride();
-        debug_assert!(img.buf.len() > 0 && img.buf.len() >= stride * img.height() + width - stride);
+        debug_assert!(img.buf().len() > 0 && img.buf().len() >= stride * img.height() + width - stride);
         Self {
-           current: img.buf[0..].as_ptr(),
-           current_line_end: img.buf[width..].as_ptr(),
+           current: img.buf()[0..].as_ptr(),
+           current_line_end: img.buf()[width..].as_ptr(),
            width,
            y: img.height(),
            pad: stride - width,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -14,7 +14,7 @@ macro_rules! impl_imgref_index {
                 let stride = self.stride();
                 debug_assert_eq!(stride, stride as $index as usize);
                 debug_assert!(index.0 < stride as $index);
-                &self.buf[(index.1 * (stride as $index) + index.0) as usize]
+                &self.buf()[(index.1 * (stride as $index) + index.0) as usize]
             }
         }
     }
@@ -32,7 +32,7 @@ macro_rules! impl_imgref_index_mut {
                 let stride = self.stride();
                 debug_assert_eq!(stride, stride as $index as usize);
                 debug_assert!(index.0 < stride as $index);
-                &mut self.buf[(index.1 * (stride as $index) + index.0) as usize]
+                &mut self.buf_mut()[(index.1 * (stride as $index) + index.0) as usize]
             }
         }
     }


### PR DESCRIPTION
Hello,

This adds accessors to `Img`'s `buf` member and deprecates direct access to it.

I "need" this because I'm using ImgRef as a container to transfer image data to OpenGL, which requires a pointer to the pixels.  
This cannot be done efficiently with iterators (technically it can, but it's hacky), and I don't feel comfortable about directly using the `buf` member knowing it will be private someday.  
In short, it feels like `Img` "steals" the container from me, and I'd like it back :)

Thanks in advance :) I acknowledge that this is probably a bit petty and the newly introduced `deprecated` warnings may annoy a bunch of people.