### PR TITLE
Add `no_std` compatibility.

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,7 +1,10 @@
-use core::num::NonZeroUsize;
 use core::iter::FusedIterator;
-use std::marker::PhantomData;
-use std::slice;
+use core::marker::PhantomData;
+use core::num::NonZeroUsize;
+use core::slice;
+
+#[cfg(test)]
+use alloc::vec;
 
 /// Rows of the image. Call `Img.rows()` to create it.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,15 @@
 //!  }
 //!  ```
 
-use std::borrow::Cow;
-use std::slice;
+#![no_std]
+
+extern crate alloc;
+#[cfg(test)]
+extern crate std;
+
+use alloc::borrow::{Cow, ToOwned};
+use alloc::vec::Vec;
+use core::slice;
 
 mod traits;
 
@@ -322,7 +329,7 @@ impl<'a, T> ImgRef<'a, T> {
     ///
     /// Note: it iterates **all** pixels in the underlying buffer, not just limited by width/height.
     #[deprecated(note = "Size of this buffer is unpredictable. Use .rows() instead")]
-    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+    pub fn iter(&self) -> slice::Iter<'_, T> {
         self.buf().iter()
     }
 }
@@ -535,7 +542,7 @@ impl<T> ImgVec<T> {
     }
 
     #[deprecated(note = "Size of this buffer may be unpredictable. Use .rows() instead")]
-    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+    pub fn iter(&self) -> slice::Iter<'_, T> {
         self.buf().iter()
     }
 
@@ -732,6 +739,7 @@ impl<T> Img<T> where T: ToOwned {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     mod with_opinionated_container {
         use super::*;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,5 +1,9 @@
 use super::Img;
-use std::ops;
+use alloc::vec::Vec;
+use core::ops;
+
+#[cfg(test)]
+use alloc::vec;
 
 macro_rules! impl_imgref_index {
     ($container:ty, $index:ty) => {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,5 @@
-use std::hash::{Hasher, Hash};
-use crate::{ImgRef, ImgVec, ImgRefMut};
+use crate::{ImgRef, ImgRefMut, ImgVec};
+use core::hash::{Hash, Hasher};
 
 impl<'a, T: Hash> Hash for ImgRef<'a, T> {
     #[allow(deprecated)]
@@ -98,6 +98,8 @@ impl<T: Eq> Eq for ImgVec<T> {
 
 #[test]
 fn test_eq_hash() {
+    use alloc::vec;
+
     #[derive(Debug)]
     struct Comparable(u16);
     impl PartialEq<u8> for Comparable {


### PR DESCRIPTION
No functional changes were required; only different imports.