### PR TITLE
Allow `ImgRef::rows()` to outlive the `ImgRef`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,7 +349,7 @@ impl<'a, T> ImgRef<'a, T> {
     /// If stride is 0
     ///
     /// See also `pixels()`
-    pub fn rows(&self) -> RowsIter<'_, T> {
+    pub fn rows(&self) -> RowsIter<'a, T> {
         self.rows_buf_internal(self.buf())
     }
 


### PR DESCRIPTION
This allows returning an iterator based on `rows()` from a function, or otherwise having it outlive the `ImgRef` value, as long as the buffer reference lives long enough.

This change applies only to `ImgRef` and not `ImgRefMut` or `ImgVec`, because `ImgRef` is the only one that can support it. (Therefore, making this change is incompatible with later deciding to make the three `fn rows()` into a single more generic method; that might be a reason not to do it.)
