### PR TITLE
Remove image from the published crates.io package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/kornelski/imgref"
 version = "1.12.0"
 edition = "2021"
 rust-version = "1.61"
+include = ["src/**/*.rs", "README.md", "Cargo.toml", "LICENSE-APACHE", "LICENSE-CC0"]
 
 [features]
 default = ["deprecated"]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ fn main() {
 
 ## Type aliases
 
-<img src="imgref.png" width="446" alt="Illustration: stride is width of the whole buffer.">
+<img src="https://raw.githubusercontent.com/kornelski/imgref/refs/heads/main/imgref.png" width="446" alt="Illustration: stride is width of the whole buffer.">
 
 These are described in [more detail in the reference](https://docs.rs/imgref).
 


### PR DESCRIPTION
During a dependency review I noticed that imgref includes an image in the published package. This file is not required for building imgref as dependency and make it a bit harder to review the code.

This commit introduces a `include` directive in the `Cargo.toml` file to explicitly include only this file required to build `imgref`. Additionally it changes the Readme to use an absulute link to the image instead so that it continues to be rendered correctly everywhere. This allows to exclude the image and also reduces the size of the published crate from 15 files, 119.0KiB (64.7KiB compressed) to 11 files, 73.6KiB (18.4KiB compressed) which results in a 65GB/Month traffic reduction for crates.io assuming the current 1.4 million downloads and the difference in the compressed package size.