### PR TITLE
Fix out-of-bounds slice in RowsIter, use correct Send/Sync bounds

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -384,3 +384,70 @@ fn iter() {
         }
     }
 }
+
+#[test]
+fn rows_iter_len_overflow_can_create_oob_slice() {
+    // `ImgRef::valid_min_len()` computes `stride * height + width - stride`
+    // with unchecked `usize` arithmetic. In release mode this wraps to `1`,
+    // so `rows()` accepts a one-element buffer for a 2x2 image with an
+    // impossible stride. `RowsIter::next()` then calls `get_unchecked(0..2)`
+    // on a one-element chunk, which violates the slice bounds precondition
+    // and is reported as UB by Miri.
+    let buf = [0u8; 1];
+    let img = super::Img::new_stride(&buf[..], 2, 2, usize::MAX);
+
+    let _ = img.rows().next();
+}
+
+#[test]
+fn pixels_ref_len_overflow_can_walk_oob() {
+    // The same unchecked length calculation can wrap to `1` for a 1x3 image.
+    // `PixelsRefIter` therefore starts from a one-element slice even though
+    // the second row would be at an enormous offset. The second `next()` moves
+    // the raw pointer by `stride - width` from the end of that one-element
+    // slice, violating `ptr::add`'s in-allocation requirement under Miri.
+    let buf = [0u8; 1];
+    let img = super::Img::new_stride(&buf[..], 1, 3, usize::MAX / 2 + 1);
+    let mut pixels = img.pixels_ref();
+
+    let _ = pixels.next();
+    let _ = pixels.next();
+}
+
+#[test]
+fn pixels_ref_iter_send_allows_cell_data_race() {
+    // `PixelsRefIter<'_, T>` is `Send` when `T: Send`, but it yields `&T`
+    // values in the receiving thread. Shared references may cross threads
+    // only when `T: Sync`. `Cell<u32>` is `Send` but not `Sync`, so the safe
+    // API below sends an iterator to another thread and mutates the same
+    // `Cell` from both threads without synchronization. Miri reports this as
+    // a data race.
+    use core::cell::Cell;
+
+    let buf = [Cell::new(0u32)];
+    let img = super::Img::new(&buf[..], 1, 1);
+    let mut pixels = img.pixels_ref();
+
+    std::thread::scope(|scope| {
+        let handle = scope.spawn(move || {
+            pixels.next().unwrap().set(1);
+        });
+
+        buf[0].set(2);
+        handle.join().unwrap();
+    });
+}
+
+#[test]
+fn pixels_mut_len_overflow_can_walk_oob() {
+    // Mutable pixel iteration has the same invariant: after the wrapped
+    // `valid_min_len()` accepts a one-element mutable slice, the second
+    // `next()` computes a raw pointer far outside that slice. Miri reports the
+    // out-of-bounds `ptr::add` before any invalid reference needs to be used.
+    let mut buf = [0u8; 1];
+    let mut img = super::Img::new_stride(&mut buf[..], 1, 3, usize::MAX / 2 + 1);
+    let mut pixels = img.pixels_mut();
+
+    let _ = pixels.next();
+    let _ = pixels.next();
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -184,7 +184,7 @@ pub struct PixelsRefIter<'a, T> {
     _dat: PhantomData<&'a [T]>,
 }
 
-unsafe impl<T> Send for PixelsRefIter<'_, T> where T: Send {}
+unsafe impl<T> Send for PixelsRefIter<'_, T> where T: Sync {}
 unsafe impl<T> Sync for PixelsRefIter<'_, T> where T: Sync {}
 
 impl<'a, T: 'a> PixelsRefIter<'a, T> {
@@ -386,13 +386,12 @@ fn iter() {
 }
 
 #[test]
+#[should_panic(expected = "Invalid ImgRef params")]
 fn rows_iter_len_overflow_can_create_oob_slice() {
     // `ImgRef::valid_min_len()` computes `stride * height + width - stride`
-    // with unchecked `usize` arithmetic. In release mode this wraps to `1`,
-    // so `rows()` accepts a one-element buffer for a 2x2 image with an
-    // impossible stride. `RowsIter::next()` then calls `get_unchecked(0..2)`
-    // on a one-element chunk, which violates the slice bounds precondition
-    // and is reported as UB by Miri.
+    // using checked arithmetic. It must panic on overflow instead of accepting
+    // a one-element buffer for a 2x2 image with an impossible stride and later
+    // reaching `RowsIter::next()`'s unsafe `get_unchecked(0..2)`.
     let buf = [0u8; 1];
     let img = super::Img::new_stride(&buf[..], 2, 2, usize::MAX);
 
@@ -400,12 +399,11 @@ fn rows_iter_len_overflow_can_create_oob_slice() {
 }
 
 #[test]
+#[should_panic(expected = "Invalid ImgRef params")]
 fn pixels_ref_len_overflow_can_walk_oob() {
-    // The same unchecked length calculation can wrap to `1` for a 1x3 image.
-    // `PixelsRefIter` therefore starts from a one-element slice even though
-    // the second row would be at an enormous offset. The second `next()` moves
-    // the raw pointer by `stride - width` from the end of that one-element
-    // slice, violating `ptr::add`'s in-allocation requirement under Miri.
+    // The same checked length calculation must panic on overflow for a 1x3
+    // image, rather than letting `PixelsRefIter` start from a one-element slice
+    // and later move the raw pointer far outside the allocation.
     let buf = [0u8; 1];
     let img = super::Img::new_stride(&buf[..], 1, 3, usize::MAX / 2 + 1);
     let mut pixels = img.pixels_ref();
@@ -415,35 +413,48 @@ fn pixels_ref_len_overflow_can_walk_oob() {
 }
 
 #[test]
-fn pixels_ref_iter_send_allows_cell_data_race() {
-    // `PixelsRefIter<'_, T>` is `Send` when `T: Send`, but it yields `&T`
-    // values in the receiving thread. Shared references may cross threads
-    // only when `T: Sync`. `Cell<u32>` is `Send` but not `Sync`, so the safe
-    // API below sends an iterator to another thread and mutates the same
-    // `Cell` from both threads without synchronization. Miri reports this as
-    // a data race.
+fn pixels_ref_iter_send_requires_sync_pixels() {
+    // `PixelsRefIter<'_, T>` yields `&T`, so sending it to another thread is
+    // only sound when `T: Sync`. `Cell<u32>` is `Send` but not `Sync`; if the
+    // iterator were `Send` for `T: Send`, safe code could create a data race by
+    // sending the iterator to another thread while retaining local shared
+    // access to the same cell.
     use core::cell::Cell;
 
-    let buf = [Cell::new(0u32)];
-    let img = super::Img::new(&buf[..], 1, 1);
-    let mut pixels = img.pixels_ref();
+    macro_rules! assert_not_impl_any {
+        ($x:ty: $($t:path),+ $(,)?) => {
+            const _: fn() = || {
+                trait AmbiguousIfImpl<A> { fn some_item() {} }
+                impl<T: ?Sized> AmbiguousIfImpl<()> for T {}
+                impl<T: ?Sized $(+ $t)+> AmbiguousIfImpl<u8> for T {}
+                <$x as AmbiguousIfImpl<_>>::some_item()
+            };
+        };
+    }
 
-    std::thread::scope(|scope| {
-        let handle = scope.spawn(move || {
-            pixels.next().unwrap().set(1);
-        });
+    fn assert_send<T: Send>() {}
 
-        buf[0].set(2);
-        handle.join().unwrap();
-    });
+    assert_send::<PixelsRefIter<'static, u32>>();
+    assert_not_impl_any!(PixelsRefIter<'static, Cell<u32>>: Send);
 }
 
 #[test]
+#[should_panic(expected = "Invalid ImgRef params")]
+fn pixels_mut_len_overflow_can_create_oob_line_end() {
+    // `PixelsIterMut::new()` computes `ptr.add(width)` for the first row's
+    // line end. Checked validation must reject this wrapped 2x2 image before
+    // creating a one-element mutable slice where that pointer is out of bounds.
+    let mut img = super::Img::new_stride(vec![0u8; 1], 2, 2, usize::MAX);
+
+    let _ = img.pixels_mut();
+}
+
+#[test]
+#[should_panic(expected = "Invalid ImgRef params")]
 fn pixels_mut_len_overflow_can_walk_oob() {
-    // Mutable pixel iteration has the same invariant: after the wrapped
-    // `valid_min_len()` accepts a one-element mutable slice, the second
-    // `next()` computes a raw pointer far outside that slice. Miri reports the
-    // out-of-bounds `ptr::add` before any invalid reference needs to be used.
+    // Mutable pixel iteration has the same invariant: checked validation must
+    // reject this wrapped 1x3 image before the second row would require raw
+    // pointer arithmetic far outside the one-element allocation.
     let mut buf = [0u8; 1];
     let mut img = super::Img::new_stride(&mut buf[..], 1, 3, usize::MAX / 2 + 1);
     let mut pixels = img.pixels_mut();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,7 +681,7 @@ impl<Container> Img<Container> {
 #[cold]
 #[inline(never)]
 #[cfg_attr(debug_assertions, track_caller)]
-fn imgref_invalid_size(width: u32, height: u32, stride: usize, min_size: usize, len: usize) {
+fn imgref_invalid_size(width: u32, height: u32, stride: usize, min_size: usize, len: usize) -> ! {
     panic!("Invalid ImgRef params. Got stride={stride} for {width}×{height}; len={len} (needed {min_size})");
 }
 
@@ -705,10 +705,24 @@ impl<'buf, T> ImgRef<'buf, T> {
         let stride = self.stride();
         let width = self.width();
         let height = self.height();
-        let min_size = if height == 0 || width == 0 { 0 } else { stride * height + width - stride };
         let buf = self.buf();
         #[allow(deprecated)]
-        if stride == 0 || stride < width || buf.len() < min_size {
+        if stride == 0 || stride < width {
+            imgref_invalid_size(self.width, self.height, stride, 0, buf.len());
+        }
+        #[allow(deprecated)]
+        let min_size = if height == 0 || width == 0 {
+            0
+        } else {
+            stride
+                .checked_mul(height - 1)
+                .and_then(|len| len.checked_add(width))
+                .unwrap_or_else(|| {
+                    imgref_invalid_size(self.width, self.height, stride, usize::MAX, buf.len())
+                })
+        };
+        #[allow(deprecated)]
+        if buf.len() < min_size {
             imgref_invalid_size(self.width, self.height, stride, min_size, buf.len());
         }
         min_size


### PR DESCRIPTION
The first commit adds test cases that trigger UB under miri. The second commit fixes the UB and converts the PoCs into regression tests.

### Credits

The issues were identified by GPT-5.5 xhigh and then verified manually.